### PR TITLE
Add safety checks in BagSpawner

### DIFF
--- a/Assets/Scripts/BagSpawner.cs
+++ b/Assets/Scripts/BagSpawner.cs
@@ -31,13 +31,35 @@ public class BagSpawner : MonoBehaviour
 
     public void SpawnBag()
     {
+        if (bagPrefab == null)
+        {
+            Debug.LogWarning("BagSpawner: bagPrefab is not assigned.");
+            return;
+        }
+
+        if (waypoints == null || waypoints.Length < 3)
+        {
+            Debug.LogWarning("BagSpawner: Not enough waypoints assigned.");
+            return;
+        }
+
         GameObject bag = Instantiate(bagPrefab, waypoints[2].position, Quaternion.identity);
         AirportBag bagScript = bag.GetComponent<AirportBag>();
 
         if (bagScript != null)
         {
-            int label = Random.Range(0, bagSprites.Length);
-            Sprite assignedSprite = bagSprites[label];
+            int label = 0;
+            Sprite assignedSprite = null;
+
+            if (bagSprites != null && bagSprites.Length > 0)
+            {
+                label = Random.Range(0, bagSprites.Length);
+                assignedSprite = bagSprites[label];
+            }
+            else
+            {
+                Debug.LogWarning("BagSpawner: bagSprites array is empty.");
+            }
 
             bagScript.enabled = false;
             bagScript.speed = bagSpeed;


### PR DESCRIPTION
## Summary
- Guard bag spawning against missing prefab or insufficient waypoints
- Safely select random bag sprite only when array is populated

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688efc17d6948324bbcf4162b190666f