### PR TITLE
Add AGENTS instructions for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS
+
+These instructions apply to the entire repository.
+
+- Run `python -m pytest` and ensure it passes before committing any change.
+- Use clear, descriptive commit messages.
+- Keep the working tree clean; commit only the files related to your change.
+- Avoid committing large binary assets when possible.
+- Prefer `rg` for searching through the repository instead of `grep -R` or `ls -R`.
+


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository guidelines for contributors

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f0122474483248b8e3ad6f0266ce4